### PR TITLE
fix: prevent stats worker from caching bad values

### DIFF
--- a/workers/github-stats-fetcher/index.js
+++ b/workers/github-stats-fetcher/index.js
@@ -32,6 +32,12 @@ async function updateStats(env) {
   // Fetch repos once, share between stats and languages
   const repos = await fetchAllRepos(headers);
 
+  // Abort if repo fetch failed — prevents caching bad values (e.g. 0 stars)
+  if (repos.length === 0) {
+    console.log("GitHub stats skipped: repo fetch returned empty (likely rate-limited)");
+    return;
+  }
+
   const [stats, languages] = await Promise.allSettled([
     fetchUserStats(headers, repos),
     fetchTopLanguages(headers, repos),
@@ -63,6 +69,7 @@ async function updateStats(env) {
   if (langsSvg) await env.GITHUB_KV.put("svg:languages", langsSvg);
 
   console.log("GitHub stats updated:", JSON.stringify(mergedStats));
+
 }
 
 // --- Data Fetching ---


### PR DESCRIPTION
## Summary
- Add early return in `github-stats-fetcher` worker when `fetchAllRepos` returns empty (rate-limited), preventing it from overwriting good cached KV data with zeros
- Added `GITHUB_KV` binding to `wrangler.toml` (gitignored, deployed directly to Cloudflare) so the Pages Function can serve the stats SVGs

## Context
The stats SVGs on the GitHub profile were broken because:
1. `GITHUB_KV` binding was missing from the Pages config — the function couldn't read from KV
2. The worker had previously cached `stars: 0` and empty languages after a rate-limited GitHub API response, and the merge strategy treated these as valid values

## Test plan
- [x] Verified both endpoints return correct SVGs: `khalidwar.com/api/v1/github-stats?type=stats` and `?type=languages`
- [x] Confirmed stats match GitHub API: 176 stars, 2.3K commits, 77 PRs
- [x] Confirmed languages: JavaScript 69%, Dart 30.5%, HTML 0.4%
- [x] Worker deployed and tested via HTTP trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)